### PR TITLE
LLM inference benchmarks rollout to 100 servers

### DIFF
--- a/inspector/tasks.py
+++ b/inspector/tasks.py
@@ -191,6 +191,7 @@ llm = DockerTask(
     # might be slow when testing large models
     timeout=timedelta(hours=1),
     priority=11,
+    rollout=0.05,  # ~100 servers
     image="ghcr.io/sparecores/benchmark-llm:main",
     command=None,
 )

--- a/inspector/tasks.py
+++ b/inspector/tasks.py
@@ -185,3 +185,12 @@ passmark = DockerTask(
     image="ghcr.io/sparecores/benchmark-passmark:main",
     command=None,
 )
+
+llm = DockerTask(
+    parallel=False,
+    # might be slow when testing large models
+    timeout=timedelta(hours=1),
+    priority=11,
+    image="ghcr.io/sparecores/benchmark-llm:main",
+    command=None,
+)


### PR DESCRIPTION
The new benchmark should take 15-35 mins on the server, depending if it can load larger models. This PR also introduces a new field for the tasks to control rollout, e.g. the current setting is testing the benchmarks on ~100 servers, so that we can capture problems without burning too much credits/money.